### PR TITLE
Added stringify operator

### DIFF
--- a/crc32.nimble
+++ b/crc32.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "juancarlospaco"
 description   = "CRC32, 2 proc, copied from RosettaCode."
 license       = "MIT"

--- a/src/crc32.nim
+++ b/src/crc32.nim
@@ -1,5 +1,11 @@
+from strutils import toHex
+
 type
   TCrc32* = uint32
+
+
+proc `$`*(crc: TCrc32): string =
+  result = crc.int64.toHex(8)
 
 
 const InitCrc32* = TCrc32(0)
@@ -47,5 +53,4 @@ proc crc32FromFile*(filename: string): TCrc32 =
 
 
 when is_main_module:
-  from strutils import toHex
-  echo crc32("The quick brown fox jumps over the lazy dog.").int64.toHex(8)
+  echo crc32("The quick brown fox jumps over the lazy dog.")


### PR DESCRIPTION
CRC32 value are commonly prestented in hex format hence it being worth
providing a stringify operator that deals with this.