### PR TITLE
Fix calling deprecated read chars

### DIFF
--- a/src/crc32.nim
+++ b/src/crc32.nim
@@ -25,8 +25,9 @@ func createCrcTable(): array[0..255, uint32] =
       else: rem = rem shr 1
     result[i] = rem
 
-template updateCrc32(c: char, crc: var uint32) =
-  crc = (crc shr 8) xor static(createCrcTable())[uint32(crc and 0xff) xor uint32(ord(c))]
+template updateCrc32(c: char; crc: var uint32) =
+  crc = (crc shr 8) xor static(createCrcTable())[uint32(crc and
+      0xff) xor uint32(ord(c))]
 
 func crc32*(input: var string) =
   var crcuint = uint32(0xFFFFFFFF)
@@ -54,21 +55,22 @@ runnableExamples:
   from std/sugar import dup
 
   var x = "The quick brown fox jumps over the lazy dog."
-  crc32(x)  ## In-Place.
+  crc32(x) ## In-Place.
   doAssert x == "519025E9"
-  doAssert "The quick brown fox jumps over the lazy dog.".dup(crc32) == "519025E9"  ## Out-Place.
+  doAssert "The quick brown fox jumps over the lazy dog.".dup(crc32) ==
+      "519025E9" ## Out-Place.
 
   var e = " "
-  crc32(e)  ## In-Place.
+  crc32(e) ## In-Place.
   doAssert e == "E96CCF45"
-  doAssert " ".dup(crc32) == "E96CCF45"  ## Out-Place.
+  doAssert " ".dup(crc32) == "E96CCF45" ## Out-Place.
 
   var z = ""
-  crc32(z)   ## In-Place.
+  crc32(z) ## In-Place.
   doAssert z == "00000000"
-  doAssert "".dup(crc32) == "00000000"  ## Out-Place.
+  doAssert "".dup(crc32) == "00000000" ## Out-Place.
 
   var f = "crc32.nim"
-  crc32FromFile(f)  ## In-Place.
+  crc32FromFile(f) ## In-Place.
   echo f
-  echo "crc32.nim".dup(crc32FromFile)  ## Out-Place.
+  echo "crc32.nim".dup(crc32FromFile) ## Out-Place.

--- a/src/crc32.nim
+++ b/src/crc32.nim
@@ -42,7 +42,7 @@ proc crc32FromFile*(path: var string; bufferSize: static[Positive] = 8192) =
     buf {.noinit.}: array[bufferSize, char]
   if not open(bin, path): return
   while true:
-    var readBytes = bin.readChars(buf, 0, bufferSize)
+    var readBytes = bin.readChars(toOpenArray(buf, 0, bufferSize - 1))
     for i in countup(0, readBytes - 1): updateCrc32(buf[i], crcuint)
     if readBytes != bufferSize: break
   close(bin)


### PR DESCRIPTION
Hello,

the version of `readChars` used is deprecated, see [here](https://nim-lang.org/docs/io.html#readChars%2CFile%2CopenArray%5Bchar%5D%2CNatural%2CNatural).
This pull request updates to the newer version and additionally formats crc32.nim as suggested by nimpretty.

As there is not much action in this repository, I would like to propose an update to v0.5.1?