### PR TITLE
use correct readChars overlad on Nim < 1.5

### DIFF
--- a/src/crc32.nim
+++ b/src/crc32.nim
@@ -43,7 +43,10 @@ proc crc32FromFile*(path: var string; bufferSize: static[Positive] = 8192) =
     buf {.noinit.}: array[bufferSize, char]
   if not open(bin, path): return
   while true:
-    var readBytes = bin.readChars(toOpenArray(buf, 0, bufferSize - 1))
+    when (NimMinor > 4):
+      var readBytes = bin.readChars(toOpenArray(buf, 0, bufferSize - 1))
+    else:
+      var readBytes = bin.readChars(buf, 0, bufferSize)
     for i in countup(0, readBytes - 1): updateCrc32(buf[i], crcuint)
     if readBytes != bufferSize: break
   close(bin)

--- a/src/crc32.nim
+++ b/src/crc32.nim
@@ -43,10 +43,12 @@ proc crc32FromFile*(path: var string; bufferSize: static[Positive] = 8192) =
     buf {.noinit.}: array[bufferSize, char]
   if not open(bin, path): return
   while true:
-    when (NimMinor > 4):
-      var readBytes = bin.readChars(toOpenArray(buf, 0, bufferSize - 1))
-    else:
+    when (NimMajor < 1 or (NimMajor == 1 and NimMinor < 5)):
+      # use old readChars overload for Nim versions < 1.5
       var readBytes = bin.readChars(buf, 0, bufferSize)
+    else:
+      # use new readChars overload for Nim versions >= 1.5
+      var readBytes = bin.readChars(toOpenArray(buf, 0, bufferSize - 1))
     for i in countup(0, readBytes - 1): updateCrc32(buf[i], crcuint)
     if readBytes != bufferSize: break
   close(bin)


### PR DESCRIPTION
Hello,

my last commit removed the deprecation notice on Nim > 1.4.x but broke compilation on older versions because they do not have the new `readChars` overload.

This PR adds a compile time check to select the suitable overload depending on the minor Nim compiler version.